### PR TITLE
Fix manifest and z-index for FAB

### DIFF
--- a/src/components/AddExerciseFab.tsx
+++ b/src/components/AddExerciseFab.tsx
@@ -9,7 +9,7 @@ interface AddExerciseFabProps {
 export function AddExerciseFab({ onAddExercise }: AddExerciseFabProps) {
   return (
     <button
-      className="fixed bottom-6 right-6 w-14 h-14 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-3xl shadow-lg hover:scale-105 transition-transform"
+      className="fixed bottom-6 right-6 z-[9999] w-14 h-14 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-3xl shadow-lg hover:scale-105 transition-transform"
       onClick={onAddExercise}
       aria-label="Add exercise"
     >

--- a/src/components/NewWorkoutFab.tsx
+++ b/src/components/NewWorkoutFab.tsx
@@ -10,7 +10,7 @@ export function NewWorkoutFab() {
   const [creating, setCreating] = useState(false)
   return (
     <button
-      className="fixed bottom-6 right-6 w-14 h-14 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-3xl shadow-[0_6px_24px_rgba(0,0,0,0.35)] disabled:opacity-60"
+      className="fixed bottom-6 right-6 z-[9999] w-14 h-14 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-3xl shadow-[0_6px_24px_rgba(0,0,0,0.35)] disabled:opacity-60"
       disabled={creating}
       onClick={async () => {
         try {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -23,6 +23,10 @@ export const Route = createRootRouteWithContext<{
         content: 'width=device-width, initial-scale=1',
       },
       {
+        name: 'theme-color',
+        content: '#7f22fe',
+      },
+      {
         title: "Lift PR's",
       },
     ],
@@ -45,7 +49,7 @@ export const Route = createRootRouteWithContext<{
         sizes: '16x16',
         href: '/favicon-16x16.png',
       },
-      { rel: 'manifest', href: '/site.webmanifest', color: '#fffff' },
+      { rel: 'manifest', href: '/manifest.json' },
       { rel: 'icon', href: '/favicon.ico' },
       { rel: 'icon', href: '/icon.png' },
     ],


### PR DESCRIPTION
Fix web app manifest application and prevent FAB button overlap with menus.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee190a23-4457-4308-917d-a83ab243a3ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee190a23-4457-4308-917d-a83ab243a3ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

